### PR TITLE
fix exception while saving file.

### DIFF
--- a/src/simplesvg/SimpleSvg.py
+++ b/src/simplesvg/SimpleSvg.py
@@ -326,7 +326,7 @@ class SimpleSvg:
         else:
             symbolFeatureMap.update({symbol:[feature]})
       else:
-        if len(symbolFeatureMap[symbol])==0:
+        if not symbol in symbolFeatureMap or len(symbolFeatureMap[symbol])==0:
           symbolFeatureMap[symbol]=[feature]
         else:
           symbolFeatureMap[symbol].append(feature)


### PR DESCRIPTION
An error has occured while executing Python code:

Traceback (most recent call last):
  File "C:\Users\scotth/.qgis2/python/plugins\simplesvg\SimpleSvg.py", line 142, in writeToFile
    output = self.writeSVG()
  File "C:\Users\scotth/.qgis2/python/plugins\simplesvg\SimpleSvg.py", line 207, in writeSVG
    svg.extend(self.writeVectorLayer(layer, False))
  File "C:\Users\scotth/.qgis2/python/plugins\simplesvg\SimpleSvg.py", line 330, in writeVectorLayer
    if len(symbolFeatureMap[symbol])==0:
KeyError: None

Python version:
2.7.5 (default, May 15 2013, 22:44:16) [MSC v.1500 64 bit (AMD64)]
